### PR TITLE
Atsiminti lankytinų vietų filtro pasirinkimus

### DIFF
--- a/src/components/PlacesFeature.tsx
+++ b/src/components/PlacesFeature.tsx
@@ -25,7 +25,7 @@ export function PlacesFeature({
   setMobileActiveMode,
 }: PlacesFeatureProps) {
   const { current: mapRef } = useMap();
-  const [filterTypes, setFilterTypes]= useState(() => {
+  const [filterTypes, setFilterTypes] = useState(() => {
     if (typeof window === "undefined") {
       return "";
     }


### PR DESCRIPTION
Lankytinų vietų filtro pasirinkimai iš karto įrašomi į localstorage ir vėliau iš ten ištraukiami, grįžtant į places profilį ar šiaip iš naujo atsidarant aplikaciją.