### PR TITLE
Katalogo LT rikiavimas + maplibre-gl v6 fix'as

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "clsx": "^2.1.1",
         "js-yaml": "^5.2.2",
         "lucide-react": "^1.27.0",
-        "maplibre-gl": "^6.0.0",
+        "maplibre-gl": "^5.24.0",
         "next": "16.2.12",
         "pg": "^8.22.0",
         "radix-ui": "^1.6.7",
@@ -875,14 +875,35 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
-      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^5.0.0"
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/@mapbox/vector-tile/node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@maplibre/geojson-vt": {
@@ -895,12 +916,12 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz",
-      "integrity": "sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==",
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
+      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
@@ -4417,25 +4438,27 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.0.0.tgz",
-      "integrity": "sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.2.0",
-        "@mapbox/unitbezier": "^1.0.0",
-        "@mapbox/vector-tile": "^3.0.0",
-        "@maplibre/geojson-vt": "^6.1.1",
-        "@maplibre/maplibre-gl-style-spec": "^26.1.0",
-        "@maplibre/mlt": "^1.1.12",
-        "@maplibre/vt-pbf": "^4.3.2",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
         "@types/geojson": "^7946.0.16",
-        "earcut": "^3.2.3",
+        "earcut": "^3.0.2",
         "gl-matrix": "^3.4.4",
-        "kdbush": "^4.1.0",
+        "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^5.1.2",
+        "pbf": "^4.0.1",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
@@ -4448,11 +4471,17 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
-    "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
-      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
-      "license": "BSD-2-Clause"
+    "node_modules/maplibre-gl/node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clsx": "^2.1.1",
     "js-yaml": "^5.2.2",
     "lucide-react": "^1.27.0",
-    "maplibre-gl": "^6.0.0",
+    "maplibre-gl": "^5.24.0",
     "next": "16.2.12",
     "pg": "^8.22.0",
     "radix-ui": "^1.6.7",

--- a/src/app/katalogas/[[...params]]/_components/ObjectsList.tsx
+++ b/src/app/katalogas/[[...params]]/_components/ObjectsList.tsx
@@ -1,5 +1,6 @@
 import { HelpCircle, MapPin } from "lucide-react";
 import type { ClassObject } from "@/data/omProfileClassObjects";
+import { ltCollator } from "@/lib/utils";
 
 interface ObjectsListProps {
   objects: ClassObject[];
@@ -22,7 +23,11 @@ export function ObjectsList({ objects }: ObjectsListProps) {
     return acc;
   }, {});
 
-  const letters = Object.keys(grouped).sort();
+  for (const list of Object.values(grouped)) {
+    list.sort((a, b) => ltCollator.compare(a.name, b.name));
+  }
+
+  const letters = Object.keys(grouped).sort((a, b) => ltCollator.compare(a, b));
 
   return (
     <div className="space-y-6">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,6 +22,9 @@ export function toSafeHttpUrl(value: string): string | null {
   }
 }
 
+// Collator for sorting strings by the Lithuanian alphabet (A Ą B C Č ... Z Ž)
+export const ltCollator = new Intl.Collator("lt");
+
 // Matches om_slugify() PostgreSQL function logic
 export function slugify(str: string): string {
   if (!str) return "";


### PR DESCRIPTION
## Summary
- Taisomas #56 — kataloge indekso raidės (ir jų viduje esantys objektai) dabar rikiuojami pagal lietuvišką abėcėlę (`Intl.Collator("lt")`), o ne pagal Unicode kodų tvarką.
- Grąžinamas `maplibre-gl` iš v6 į v5.24.0 — v6 (pakelta praeitame commit'e kartu su kitomis priklausomybėmis) sulaužė `/maps`: `react-map-gl@8.1.1` (naujausia esama versija) nesuderinama su maplibre-gl v6 pakeistu vidiniu transform API, dėl ko žemėlapis lūždavo pirmo resize metu su `TypeError: Cannot read properties of undefined (reading 'center')`.

## Test plan
- [x] `npm run format` + `npm run lint` be naujų klaidų
- [x] Vizualiai patikrinta Chrome: `/katalogas/craftbeer/pubs` — rikiavimas
- [x] Vizualiai patikrinta Chrome: `/maps` — su maplibre-gl v6 žemėlapis nekraudavo (patvirtinta klaida konsolėje), su v5 vėl veikia
- [ ] Patikrinti prod po deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)