### PR TITLE
Fix: server action body size limit nuotraukų įkėlimui

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -37,11 +37,13 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  serverActions: {
-    // Nuotraukų įkėlimas leidžia iki 10 failų po 10 MB viename veiksme
-    // (žr. MAX_FILES_PER_UPLOAD / MAX_FILE_SIZE_BYTES src/actions/photos.ts),
-    // todėl limitas turi apimti visą tą kiekį + multipart overhead.
-    bodySizeLimit: "110mb",
+  experimental: {
+    serverActions: {
+      // Nuotraukų įkėlimas leidžia iki 10 failų po 10 MB viename veiksme
+      // (žr. MAX_FILES_PER_UPLOAD / MAX_FILE_SIZE_BYTES src/actions/photos.ts),
+      // todėl limitas turi apimti visą tą kiekį + multipart overhead.
+      bodySizeLimit: "110mb",
+    },
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -38,7 +38,10 @@ const nextConfig: NextConfig = {
     ];
   },
   serverActions: {
-    bodySizeLimit: "10mb",
+    // Nuotraukų įkėlimas leidžia iki 10 failų po 10 MB viename veiksme
+    // (žr. MAX_FILES_PER_UPLOAD / MAX_FILE_SIZE_BYTES src/actions/photos.ts),
+    // todėl limitas turi apimti visą tą kiekį + multipart overhead.
+    bodySizeLimit: "110mb",
   },
 };
 


### PR DESCRIPTION
## Summary
- Nuotraukų įkėlimo veiksmas (`src/actions/photos.ts`) leidžia iki 10 failų po 10 MB viename požadyje (iki 100 MB), todėl vartotojai gaudavo `Body exceeded 1 MB limit` / server action body limit klaidą įkeliant kelias nuotraukas iš karto.
- Padidintas `serverActions.bodySizeLimit` iki `110mb`, kad apimtų maksimalų leistiną kiekį + multipart overhead.
- `serverActions` perkeltas į `experimental` objektą — Next.js 16.2.12 `NextConfig` tipuose šis raktas dar yra `experimental` viduje; top-level variantas praėjo lokaliai, bet sulaužė production build su TS klaida `Object literal may only specify known properties, and 'serverActions' does not exist in type 'NextConfig'`.

## Test plan
- [x] `npm run format` / `npm run lint` švarūs (be naujų warning'ų)
- [x] `npx tsc --noEmit` nerodo klaidų dėl `next.config.ts`
- [ ] Po merge paleisti release ir patikrinti, kad `npm run build` / Docker build praeina bei kelių nuotraukų įkėlimas veikia produkcijoje

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjayrK75LVtgpjeNur8iMu)_